### PR TITLE
Handle fetch movies edge function errors gracefully

### DIFF
--- a/src/hooks/useMovies.ts
+++ b/src/hooks/useMovies.ts
@@ -68,7 +68,15 @@ export const useMovies = (options: UseMoviesOptions = {}) => {
         throw new Error(functionError.message);
       }
 
-      if (!data || !data.movies) {
+      if (!data) {
+        throw new Error('No movie data received');
+      }
+
+      if (data.error) {
+        throw new Error(data.error);
+      }
+
+      if (!data.movies) {
         throw new Error('No movie data received');
       }
 


### PR DESCRIPTION
## Summary
- make the fetch-movies edge function resilient to requests without a JSON body and return graceful error payloads instead of 500s
- surface edge-function error messages in the movies hook so the UI can show a descriptive failure state

## Testing
- npm run lint *(fails: pre-existing lint violations in unrelated UI files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e74ef748832096cfb5a730bfab48